### PR TITLE
history,state.data doesn't seem to exist, so removed it.

### DIFF
--- a/src/app/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/components/breadcrumbs/breadcrumbs.component.html
@@ -7,7 +7,7 @@
       <li
         class="bcrumbs__list-item js-list-item"
         *ngFor="let link of breadcrumbsLinks; let i = index"
-        (click)="handleBreadcrumbClick($event, link.url, i, link.data)"
+        (click)="handleBreadcrumbClick($event, link.url, i)"
         data-id="{{ link.url }}"
       >
         <i class="fas fa-arrow-left bcrumbs__list-icon"></i>{{ link.name }}

--- a/src/app/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/components/breadcrumbs/breadcrumbs.component.ts
@@ -30,9 +30,9 @@ export class BreadcrumbsComponent {
     });
   }
 
-  public handleBreadcrumbClick(e, link, id, data?) {
+  public handleBreadcrumbClick(e, link, id) {
     this.preventBreadcrumbsAdd.shouldPrevent = true;
     this.preventBreadcrumbsAdd.linkId = id;
-    this.router.navigate([link], { state: { data } });
+    this.router.navigate([link]);
   }
 }

--- a/src/app/pages/details-source/details-source.component.ts
+++ b/src/app/pages/details-source/details-source.component.ts
@@ -33,8 +33,7 @@ export class DetailsSourceComponent implements OnInit {
   ) {
     this.breadcrumbsService.setBreadcrumbs(this.breadcrumbLink);
     this.metadataPanel = this.sanitizer.bypassSecurityTrustHtml(
-      history.state.data ||
-        sessionStorage.getItem(SESSION_KEYS.METADATA_CONTENT)
+      sessionStorage.getItem(SESSION_KEYS.METADATA_CONTENT)
     );
     this.router.events.subscribe((event) => {
       if (event instanceof NavigationEnd) {
@@ -118,9 +117,7 @@ export class DetailsSourceComponent implements OnInit {
           .split(',');
 
         this.getDataService.setSourceParams(queryParams);
-        this.router.navigate([this.router.url], {
-          state: { data: history.state.data }
-        });
+        this.router.navigate([this.router.url]);
       } else {
         window.open(clickedLink.href);
       }
@@ -198,8 +195,7 @@ export class DetailsSourceComponent implements OnInit {
           }=${anchorElWrapper.title}`;
 
           this.router.navigate(
-            [decodeURI(this.router.url), anchorEl.innerText],
-            { state: { data: history.state.data } }
+            [decodeURI(this.router.url), anchorEl.innerText]
           );
           this.getDataService.setSubsequentGlossaryArticleParam(pureQueryParam);
         } else if (!!anchorEl.href) {


### PR DESCRIPTION
So, James' breadcrumbs code removed the code that sets `breadcrumb.data` to `history.state.data`. I have done some investigation on `history` and `history.state` and it seems `history.state.data` does not exist. Perhaps it does in some versions of some browsers, but it seems to me that `history.state` is a browser-defined object.

So I just stripped all that stuff out.

Do you like it?