### PR TITLE
Text link labels aligned right

### DIFF
--- a/src/app/pages/details/details.component.scss
+++ b/src/app/pages/details/details.component.scss
@@ -248,6 +248,7 @@
     a:hover {
       color: $blueDark;
     }
+    text-align: right;
   }
   .p3notes {
     .notemark {


### PR DESCRIPTION
On the occurrences page (and other three-panel pages) the text links should be aligned right, not left.
Fixes #83 